### PR TITLE
Add LambdaTester

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,8 @@ repositories {
 
 for ((sourceSetId, main) in mapOf(
     "fizzbuzz_basic" to "codes.som.anthony.oof4j.fizzbuzz.basic.BasicFizzBuzz",
-    "hello_world" to "codes.som.anthony.oof4j.helloworld.HelloWorld"
+    "hello_world" to "codes.som.anthony.oof4j.helloworld.HelloWorld", 
+    "lambda_tester" to "codes.som.anthony.oof4j.lambda_tester.LambdaTester"
 )) {
     project.sourceSets.create(sourceSetId) {
         val sourceSet = this

--- a/src/lambda_tester/README.md
+++ b/src/lambda_tester/README.md
@@ -1,0 +1,5 @@
+# Lambda Tester
+
+This demonstrates an annoying edge case for renaming methods. Lambdas 
+expressions which replace anonymous classes have to be also updated 
+correctly to prevent breaking of the polymorphic link.

--- a/src/lambda_tester/java/codes/som/anthony/oof4j/lambda_tester/LambdaTester.java
+++ b/src/lambda_tester/java/codes/som/anthony/oof4j/lambda_tester/LambdaTester.java
@@ -1,0 +1,13 @@
+package codes.som.anthony.oof4j.lambda_tester;
+
+public class LambdaTester {
+    public static void main(String[] args) {
+        String result = ((InterfaceSample) () -> "Lambdas!").getString();
+
+        System.out.println("result = " + result + " : expected = Lambdas!");
+    }
+}
+
+interface InterfaceSample {
+    String getString();
+}


### PR DESCRIPTION
Here is an edge case I found awhile ago while testing Radon's renamer. I included an example of the compiled JAR and what happens if the obfuscator does not take this edge case into consideration.

[lambda.zip](https://github.com/half-cambodian-hacker-man/oof-jvm/files/3035135/lambda.zip)
