### PR TITLE
Add 'Interface Overlap' example

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,8 @@ for ((sourceSetId, main) in mapOf(
     "hello_world" to "codes.som.anthony.oof4j.helloworld.HelloWorld", 
     "anonymous_lambda" to "codes.som.anthony.oof4j.anonymouslambda.AnonymousLambda",
     "fizzbuzz_enterprise" to "codes.som.anthony.oof4j.fizzbuzz.enterprise.EnterpriseFizzBuzzCommandLineEntryPoint",
-    "enum_constants" to "codes.som.anthony.oof4j.enumconstants.EnumConstants"
+    "enum_constants" to "codes.som.anthony.oof4j.enumconstants.EnumConstants",
+    "interface_overlap" to "codes.som.anthony.oof4j.interfaceoverlap.InterfaceOverlap"
 )) {
     project.sourceSets.create(sourceSetId) {
         val sourceSet = this

--- a/src/interface_overlap/README.md
+++ b/src/interface_overlap/README.md
@@ -1,0 +1,3 @@
+# Interface Overlap
+
+This example shows the edge case where one class implements two or more interfaces that have methods with the same signature.

--- a/src/interface_overlap/README.md
+++ b/src/interface_overlap/README.md
@@ -19,8 +19,8 @@ public interface InterfaceB {
 }
 ```
 
-This means that when we have an implementing object:
+This means that when we have an implementing object, the incorrect method can be called:
 ```java
 Object interfaceOverlap = // ...
-((InterfaceB) interfaceOverlap).a(); // Uh oh!
+((InterfaceB) interfaceOverlap).a(); // An attempt to call 'methodB' actually invokes the implementation of 'methodA'
 ```

--- a/src/interface_overlap/README.md
+++ b/src/interface_overlap/README.md
@@ -1,3 +1,26 @@
 # Interface Overlap
 
 This example shows the edge case where one class implements two or more interfaces that have methods with the same signature.
+
+When using an obfuscator that does not take this scenario into account, we can see strange behaviour: i.e.
+
+InterfaceA works fine:
+```java
+public interface InterfaceA {
+    void a(); // methodA
+    void b(); // methodB
+}
+```
+
+However, when shared inheritance is not taken into account, we see InterfaceB failing:
+```java
+public interface InterfaceB {
+    void a(); // methodB
+}
+```
+
+This means that when we have an implementing object:
+```java
+Object interfaceOverlap = // ...
+((InterfaceB) interfaceOverlap).a(); // Uh oh!
+```

--- a/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceA.java
+++ b/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceA.java
@@ -1,0 +1,6 @@
+package codes.som.anthony.oof4j.interfaceoverlap;
+
+public interface InterfaceA {
+    void methodA();
+    void methodB();
+}

--- a/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceB.java
+++ b/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceB.java
@@ -1,0 +1,5 @@
+package codes.som.anthony.oof4j.interfaceoverlap;
+
+public interface InterfaceB {
+    void methodB();
+}

--- a/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceOverlap.java
+++ b/src/interface_overlap/java/codes/som/anthony/oof4j/interfaceoverlap/InterfaceOverlap.java
@@ -1,0 +1,19 @@
+package codes.som.anthony.oof4j.interfaceoverlap;
+
+public class InterfaceOverlap implements InterfaceA, InterfaceB {
+    public static void main(String[] args) {
+        InterfaceOverlap overlap = new InterfaceOverlap();
+        overlap.methodA();
+        overlap.methodB();
+    }
+
+    @Override
+    public void methodA() {
+        System.out.println("Method A");
+    }
+
+    @Override
+    public void methodB() {
+        System.out.println("Method B");
+    }
+}


### PR DESCRIPTION
This example shows the edge case where one class implements two or more interfaces that have methods with the same signature.